### PR TITLE
Unreal 4.19 changes

### DIFF
--- a/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
+++ b/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
@@ -131,7 +131,7 @@ public:
         refContents += TEXT("\n\n");
       }
       refContents += contents;
-    } else if (!FFileHelper::LoadFileToString(lastContents, *file, 0) || lastContents != contents) {
+    } else if (!FFileHelper::LoadFileToString(lastContents, *file, FFileHelper::EHashOptions::None) || lastContents != contents) {
       if (!FFileHelper::SaveStringToFile(contents, *file, FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM)) {
         UE_LOG(LogHaxeExtern, Fatal, TEXT("Cannot write file at path %s"), *file);
       }

--- a/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
+++ b/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
@@ -1,6 +1,5 @@
 #include "IHaxeExternGenerator.h"
 #include <Features/IModularFeatures.h>
-// #include <FileHelper.h>
 #include "HaxeGenerator.h"
 #include "Misc/Paths.h"
 #include "HaxeTypes.h"

--- a/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
+++ b/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
@@ -1,6 +1,6 @@
 #include "IHaxeExternGenerator.h"
 #include <Features/IModularFeatures.h>
-#include <CoreUObject.h>
+// #include <FileHelper.h>
 #include "HaxeGenerator.h"
 #include "Misc/Paths.h"
 #include "HaxeTypes.h"

--- a/Source/UnrealHxGenerator/Public/HaxeGenerator.h
+++ b/Source/UnrealHxGenerator/Public/HaxeGenerator.h
@@ -1,5 +1,5 @@
 #pragma once
-#include <CoreUObject.h>
+#include <CoreMinimal.h>
 #include "HaxeTypes.h"
 
 namespace HaxeGenerator {

--- a/Source/UnrealHxGenerator/Public/IHaxeExternGenerator.h
+++ b/Source/UnrealHxGenerator/Public/IHaxeExternGenerator.h
@@ -2,7 +2,7 @@
 
 #include "IScriptGeneratorPluginInterface.h"
 #include "Modules/ModuleManager.h"
-#include <CoreUObject.h>
+#include <CoreMinimal.h>
 #include <cstdio>
 
 class IHaxeExternGenerator : public IScriptGeneratorPluginInterface


### PR DESCRIPTION
- clear warnings about using monolithic headers (i.e. stop using `CoreUObject.h`)
- fix VS 2017 error about implicit conversion between `int` and `FFileHelper::EHashOptions`