### PR TITLE
UE4.21 support

### DIFF
--- a/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
+++ b/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
@@ -475,10 +475,7 @@ void FHaxeGenerator::generateFields(UStruct *inStruct, bool onlyProps = false) {
         // Delegate signatures are a weird piece of code that don't seem to be exported
         continue;
       }
-      auto isEditorOnly = false;
-#if UE_VER >= 417
-      isEditorOnly = func->HasAnyFunctionFlags(FUNC_EditorOnly);
-#endif
+      auto isEditorOnly = func->HasAnyFunctionFlags(FUNC_EditorOnly);
       if (wasEditorOnlyData) {
         m_buf << TEXT("#end // WITH_EDITORONLY_DATA") << Newline();
         wasEditorOnlyData = false;
@@ -848,7 +845,7 @@ bool FHaxeGenerator::generateEnum(const EnumDescriptor *inEnum) {
   auto hxType = inEnum->haxeType;
 
   // comment
-  auto& comment = uenum->GetMetaData(TEXT("ToolTip"));
+  auto comment = uenum->GetMetaData(TEXT("ToolTip"));
   if (!comment.IsEmpty()) {
     m_buf << Comment(comment);
   }
@@ -871,11 +868,7 @@ bool FHaxeGenerator::generateEnum(const EnumDescriptor *inEnum) {
 
   m_buf << Begin(TEXT(" {"));
   for (int i = 0; i < uenum->NumEnums(); i++) {
-#if UE_VER >= 416
     auto name = uenum->GetNameStringByIndex(i);
-#else
-    auto name = uenum->GetEnumName(i);
-#endif
     auto ecomment = uenum->GetMetaData(*(name + TEXT(".") + TEXT("ToolTip")));
     auto displayName = uenum->GetMetaData(*(name + TEXT(".") + TEXT("DisplayName")));
     if (!displayName.IsEmpty()) {
@@ -1053,7 +1046,6 @@ bool FHaxeGenerator::upropType(UProperty* inProp, FString &outType) {
       return false;
     }
     return true;
-#if UE_VER >= 416
   } else if (inProp->IsA<UEnumProperty>()) {
     auto enumProp = Cast<UEnumProperty>(inProp);
     UEnum *uenum = enumProp->GetEnum();
@@ -1062,7 +1054,6 @@ bool FHaxeGenerator::upropType(UProperty* inProp, FString &outType) {
       return false;
     }
     return writeWithModifiers(descr->haxeType.toString(), inProp, outType);
-#endif
   } else if (inProp->IsA<UBoolProperty>()) {
     return writeBasicWithModifiers(TEXT("Bool"), inProp, outType);
     return true;

--- a/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
+++ b/Source/UnrealHxGenerator/Private/HaxeExternGenerator.cpp
@@ -907,7 +907,14 @@ bool FHaxeGenerator::writeWithModifiers(const FString &inName, UProperty *inProp
       end += TEXT(">");
     }
     if (inProp->HasAnyPropertyFlags(CPF_ReferenceParm)) {
-      outType += TEXT("unreal.PRef<");
+      if (inProp->IsA<UStructProperty>())
+      {
+        outType += TEXT("unreal.PRef<");
+      }
+      else
+      {
+        outType += TEXT("unreal.Ref<");
+      }
       end += TEXT(">");
     }
   } else {
@@ -923,7 +930,14 @@ bool FHaxeGenerator::writeWithModifiers(const FString &inName, UProperty *inProp
         // we don't support UObject*& for now
         return false;
       }
-      outType += TEXT("unreal.PRef<");
+      if (inProp->IsA<UStructProperty>())
+      {
+        outType += TEXT("unreal.PRef<");
+      }
+      else
+      {
+        outType += TEXT("unreal.Ref<");
+      }
       end += TEXT(">");
     }
   }

--- a/Source/UnrealHxGenerator/Public/HaxeTypes.h
+++ b/Source/UnrealHxGenerator/Public/HaxeTypes.h
@@ -9,14 +9,7 @@ DECLARE_LOG_CATEGORY_EXTERN(LogHaxeExtern, Log, All);
 #define LOG(str,...)
 #endif
 
-#include "../Launch/Resources/Version.h"
-#ifndef ENGINE_MINOR_VERSION
-#error "Version not found"
-#endif
-
 #define UHX_MAX_ENV_SIZE 32768
-
-#define UE_VER (ENGINE_MAJOR_VERSION * 100 + ENGINE_MINOR_VERSION)
 
 enum class ETypeKind {
   KNone,
@@ -474,7 +467,6 @@ public:
         // is enum
         this->touchEnum(uenum, inClass);
       }
-#if UE_VER >= 416
     } else if (inProp->IsA<UEnumProperty>()) {
       auto enumProp = Cast<UEnumProperty>(inProp);
       UEnum *uenum = enumProp->GetEnum();
@@ -482,7 +474,6 @@ public:
         // is enum
         this->touchEnum(uenum, inClass);
       }
-#endif
     } else if (inProp->IsA<UArrayProperty>()) {
       auto prop = Cast<UArrayProperty>(inProp);
       touchProperty(prop->Inner, inClass, inMayForward);


### PR DESCRIPTION
Fixed some build errors to comply with API changes in 4.21. Also dropped support for 4.16 & 4.17 as part of removing our build dependency on Version.h.